### PR TITLE
Tweak ESLint setup for TypeScript 5.9 compatibility

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -9,6 +9,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2021,
     sourceType: 'module',
+    warnOnUnsupportedTypeScriptVersion: false,
   },
   plugins: ['@typescript-eslint'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:bdd": "npm run build && npm run test:bdd:run",
     "test:jest": "npm run build && npm run test:jest:run",
     "test": "npm run build && npm run test:bdd:run && npm run test:jest:run",
-    "lint": "eslint . --ext .ts"
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .ts"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- disable the unsupported TypeScript version warning in the ESLint parser configuration
- force the lint script to keep using the legacy eslintrc flow so it continues to work with newer ESLint binaries

## Testing
- npm run lint *(fails: missing local @typescript-eslint/eslint-plugin package in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbda99ee1483218bb29f71d977af63