### PR TITLE
Document existing voice editing commands

### DIFF
--- a/docs/voice-editing-commands.md
+++ b/docs/voice-editing-commands.md
@@ -1,0 +1,78 @@
+# Voice Editing Command Reference
+
+This document summarizes the capabilities that are already implemented in the `VoiceEditor`
+module. The editor works on a tokenized view of the input text: every word, punctuation mark
+and whitespace character is stored as a separate token. Voice commands operate by moving a
+cursor across that token list and editing the word that the cursor currently references.
+
+## Preparing text for editing
+
+### `setText(text: string)`
+Tokenizes an arbitrary string using the built-in `Tokenizer` and loads the resulting tokens
+into the editor. After the text is loaded the cursor is placed on the final token in the
+sequence, matching the behaviour verified in the acceptance scenarios that start from "the
+last element" of the sample text.
+
+### `setTokens(tokens: string[])`
+Allows callers to provide a pre-tokenized array. The cursor is also positioned on the last
+token of the provided list, which mirrors the workflow used in the cucumber tests.
+
+## Inspecting the current cursor position
+
+### `getLatestToken()`
+Returns the token that is currently under the cursor. When the editor is freshly initialized
+with text this reports the last token (e.g. the trailing period in the test fixture). All
+navigation commands update the cursor before `getLatestToken()` is called again, so this is
+the method used in the tests to assert the effect of each command.
+
+## Navigating between tokens
+
+The editor exposes two low-level commands that move the cursor by single tokens. They do not
+perform any boundary checks, so callers should ensure they do not move before the first token
+or past the end of the list.
+
+- `moveElementBackward()` — moves the cursor one token to the left.
+- `moveElementForward()` — moves the cursor one token to the right.
+
+These commands are useful when voice control needs fine-grained token-level navigation (for
+example to land on punctuation or whitespace).
+
+## Navigating between words
+
+For more natural voice interactions the editor also provides word-level navigation helpers
+that skip over punctuation and whitespace until they land on the previous or next word token.
+
+### `moveWordBackward()`
+Steps over any non-word tokens immediately before the cursor, jumps one more position to skip
+the current word, and finally scans backward until it lands on the preceding word. This means
+calling the command once moves from the current word to the previous word, skipping any
+punctuation or whitespace in between.
+
+### `moveWordForward()`
+Skips over non-word tokens immediately ahead of the cursor, moves one position to leave the
+current word, and then scans forward until it reaches the next word token. If no subsequent
+word exists the cursor will end up positioned after the final token.
+
+## Editing commands
+
+### `replaceCurrentWord(newWord: string)`
+Moves the cursor backward until it points at a word and replaces that word with the provided
+value. This enables voice-driven corrections such as saying "replace current word with
+*побежал*", which is demonstrated in the cucumber feature.
+
+### `insertPhrase()` *(not implemented yet)*
+Reserved for future expansion. The method currently exists as a stub so that new insertion
+commands can be wired into the editor without changing its public surface.
+
+## Tokenization rules
+
+The helper `Tokenizer` class separates text into tokens according to the following rules:
+
+- Whitespace tokens include spaces and newline characters.
+- Punctuation tokens include characters such as `,`, `.`, `…`, `!`, `?`, dashes, parentheses
+  and guillemets.
+- Word tokens accept both Latin and Cyrillic letters as well as in-word hyphens.
+
+Understanding these rules helps when designing voice commands: the navigation helpers consider
+anything that is neither punctuation nor whitespace to be a word token, so the regexes above
+control what the editor treats as a word boundary.


### PR DESCRIPTION
## Summary
- add a documentation page that lists the VoiceEditor commands already implemented
- describe navigation, editing, and tokenization behaviour so voice workflows can reference it

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cc22017cdc8321a58b4a9b76c62072